### PR TITLE
index.tsx: fix path to libraries

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -93,7 +93,7 @@ const Home: NextPage = () => {
                 name={library.name}
                 description={library.description}
                 image={library.image}
-                link={`/icons/${library.id}`}
+                link={`/library/${library.id}`}
               />
             ))}
           </div>


### PR DESCRIPTION
Index link is set as `/icons/{library.id}`, leading to a 404 error. Path seems to be `/library/{library.id}`