### PR TITLE
Replace Next.js `<Link>` Component

### DIFF
--- a/components/Docs/Button.tsx
+++ b/components/Docs/Button.tsx
@@ -44,6 +44,7 @@ const Button: FunctionComponent<CustomButtonProps> = ({
           [classes.lightButton]: variant !== 'contained'
         })
       }}
+      component={Link}
       endIcon={renderIcon(endIcon)}
       href={href}
       startIcon={renderIcon(startIcon)}

--- a/components/Docs/Button.tsx
+++ b/components/Docs/Button.tsx
@@ -1,11 +1,11 @@
 import { FunctionComponent, ReactNode } from 'react';
-import Link from 'next/link';
 import cx from 'clsx';
 import { ButtonProps, Button as MuiButton } from '@mui/material';
 
 import { IconLibraries } from '../../interfaces/icons';
 
 import Icon from './Icon';
+import Link from '../Link/Link';
 
 import classes from './components.module.scss';
 
@@ -37,22 +37,21 @@ const Button: FunctionComponent<CustomButtonProps> = ({
   };
 
   return (
-    <Link className={classes.button} href={href} passHref>
-      <MuiButton
-        classes={{
-          root: cx({
-            [classes.darkButton]: variant === 'contained',
-            [classes.lightButton]: variant !== 'contained'
-          })
-        }}
-        startIcon={renderIcon(startIcon)}
-        endIcon={renderIcon(endIcon)}
-        variant={variant}
-        {...rest}
-      >
-        {children}
-      </MuiButton>
-    </Link>
+    <MuiButton
+      classes={{
+        root: cx(classes.button, {
+          [classes.darkButton]: variant === 'contained',
+          [classes.lightButton]: variant !== 'contained'
+        })
+      }}
+      endIcon={renderIcon(endIcon)}
+      href={href}
+      startIcon={renderIcon(startIcon)}
+      variant={variant}
+      {...rest}
+    >
+      {children}
+    </MuiButton>
   );
 };
 

--- a/components/Docs/DocView.tsx
+++ b/components/Docs/DocView.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from 'react';
-import Link from 'next/link';
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote';
 import { ButtonProps } from '@mui/material/Button';
 
@@ -9,6 +8,7 @@ import { IconLibraries, IconLibrary, MdxIconProps } from '../../interfaces/icons
 
 import Head from '../../components/Head/Head';
 import Layout from '../../components/Docs/Layout/Layout';
+import Link from '../Link/Link';
 import Contributors from '../Contributors/Contributors';
 import Heading from '../../components/Docs/Heading';
 import CodeHighlighter from '../../components/CodeHighlighter/CodeHighlighter';

--- a/components/Docs/Heading.tsx
+++ b/components/Docs/Heading.tsx
@@ -1,10 +1,11 @@
 import { ReactNode } from 'react';
 import { renderToString } from 'react-dom/server';
 import { stripHtml } from 'string-strip-html';
-import Link from 'next/link';
 import slugify from 'slugify';
 import { Icon as MDIIcon } from '@mdi/react';
 import { mdiLinkVariant } from '@mdi/js';
+
+import Link from '../Link/Link';
 
 import classes from './components.module.scss';
 

--- a/components/Docs/Layout/Layout.module.scss
+++ b/components/Docs/Layout/Layout.module.scss
@@ -29,15 +29,6 @@
   text-transform: uppercase;
 }
 
-.edits {
-  a {
-    display: block;
-    justify-content: left;
-    margin: .5rem 0;
-    text-decoration: none;
-  }
-}
-
 .breadcrumb {
   font-size: .9rem;
 }

--- a/components/Docs/TableOfContents/TableOfContents.tsx
+++ b/components/Docs/TableOfContents/TableOfContents.tsx
@@ -1,9 +1,11 @@
 import { FunctionComponent } from 'react';
-import Link from 'next/link';
 import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
+
 import { TableOfContentsItemProps, TableOfContentsProps } from '../../../interfaces/tableOfContents';
+
+import Link from '../../Link/Link';
 
 import classes from './TableOfContents.module.scss';
 

--- a/components/Docs/components.module.scss
+++ b/components/Docs/components.module.scss
@@ -14,6 +14,7 @@
 }
 
 .button {
+  margin: .25rem;
   text-decoration: none;
 
   p {

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,8 +1,9 @@
 import { FunctionComponent } from 'react';
-import Link from 'next/link';
 import IconButton from '@mui/material/IconButton';
 import Icon from '@mdi/react';
 import { siGithub, siMastodon } from 'simple-icons/icons';
+
+import Link from 'next/link';
 
 import PictogrammersLogo from '../../assets/pictogrammers-logo.svg';
 

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -22,17 +22,17 @@ const Header: FunctionComponent = () => {
   const [ menuOpen, setMenuOpen ] = useState<boolean>(false);
 
   const NavButton = ({ href, ...props }: NavButtonProps) => (
-    <Button
-      href={href}
-      onClick={() => setMenuOpen(false)}
-      sx={{
-        borderRadius: '50px',
-        fontSize: '16px',
-        padding: '.5rem 1rem',
-        textTransform: 'none'
-      }}
-      {...props}
-    />
+    <Link href={href} onClick={() => setMenuOpen(false)}>
+      <Button
+        sx={{
+          borderRadius: '50px',
+          fontSize: '16px',
+          padding: '.5rem 1rem',
+          textTransform: 'none'
+        }}
+        {...props}
+      />
+    </Link>
   );
 
   return (

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -22,17 +22,18 @@ const Header: FunctionComponent = () => {
   const [ menuOpen, setMenuOpen ] = useState<boolean>(false);
 
   const NavButton = ({ href, ...props }: NavButtonProps) => (
-    <Link href={href} onClick={() => setMenuOpen(false)}>
-      <Button
-        sx={{
-          borderRadius: '50px',
-          fontSize: '16px',
-          padding: '.5rem 1rem',
-          textTransform: 'none'
-        }}
-        {...props}
-      />
-    </Link>
+    <Button
+      component={Link}
+      href={href}
+      onClick={() => setMenuOpen(false)}
+      sx={{
+        borderRadius: '50px',
+        fontSize: '16px',
+        padding: '.5rem 1rem',
+        textTransform: 'none'
+      }}
+      {...props}
+    />
   );
 
   return (

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent, useState } from 'react';
 import cx from 'clsx';
-import Link from 'next/link';
 import Button, { ButtonProps } from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Icon from '@mdi/react';
@@ -10,6 +9,7 @@ import MdiHamburger from '../../assets/hamburger.svg';
 import PictogrammersLogo from '../../assets/pictogrammers-logo.svg';
 import PictogrammersWordmark from '../../assets/brand/logos/pictogrammers-wordmark.svg';
 
+import Link from '../Link/Link';
 import SiteSearch from '../SiteSearch/SiteSearch';
 
 import classes from './Header.module.scss';
@@ -22,17 +22,17 @@ const Header: FunctionComponent = () => {
   const [ menuOpen, setMenuOpen ] = useState<boolean>(false);
 
   const NavButton = ({ href, ...props }: NavButtonProps) => (
-    <Link href={href} onClick={() => setMenuOpen(false)} passHref>
-      <Button
-        sx={{
-          borderRadius: '50px',
-          fontSize: '16px',
-          padding: '.5rem 1rem',
-          textTransform: 'none'
-        }}
-        {...props}
-      />
-    </Link>
+    <Button
+      href={href}
+      onClick={() => setMenuOpen(false)}
+      sx={{
+        borderRadius: '50px',
+        fontSize: '16px',
+        padding: '.5rem 1rem',
+        textTransform: 'none'
+      }}
+      {...props}
+    />
   );
 
   return (

--- a/components/IconGrid/IconGrid.tsx
+++ b/components/IconGrid/IconGrid.tsx
@@ -71,6 +71,7 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, updateUrl 
         itemContent={(index, icon: IconLibraryIcon) => (
           <Link
             className={classes.libraryIcon}
+            disableRouter
             href={`/library/${library.id}/icon/${icon.n}`}
             onClick={(e: MouseEvent<HTMLAnchorElement>) => handleIconModalOpen(e, icon)}
           >

--- a/components/IconGrid/IconGrid.tsx
+++ b/components/IconGrid/IconGrid.tsx
@@ -1,13 +1,13 @@
 import { Fragment, FunctionComponent, MouseEvent, useEffect, useState } from 'react';
 import cx from 'clsx';
 import { useRouter } from 'next/router';
-import Link from 'next/link';
 import { VirtuosoGrid } from 'react-virtuoso';
 import Dialog from '@mui/material/Dialog';
 
 import useCategories, { CategoryProps } from '../../hooks/useCategories';
 import useWindowSize from '../../hooks/useWindowSize';
 
+import Link from '../Link/Link';
 import { viewModes } from '../IconLibrary/LibraryViewMode';
 import IconView from '../IconView/IconView';
 import CustomGridIcon from '../CustomGridIcon/CustomGridIcon';
@@ -42,7 +42,7 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, updateUrl 
     return () => router.events.off('routeChangeStart', handleRouteChange);
   }, [ library.id, router ]);
 
-  const handleIconModalOpen = (e: MouseEvent<HTMLAnchorElement>, icon: IconLibraryIcon) => {
+  const handleIconModalOpen = async (e: MouseEvent<HTMLAnchorElement>, icon: IconLibraryIcon) => {
     e.preventDefault();
   
     const cats = icon.t.map((tag) => categories.find((cat) => cat.id === Number(tag)));
@@ -52,14 +52,14 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, updateUrl 
     setIconModal(icon);
 
     if (updateUrl) {
-      router.push(`/library/${library.id}/icon/${icon.n}`, undefined, { shallow: true });
+      await router.push(`/library/${library.id}/icon/${icon.n}`, undefined, { shallow: true });
     }
   };
 
-  const handleIconModalClose = () => {
+  const handleIconModalClose = async () => {
     setIconModal(null);
     if (updateUrl) {
-      router.push(`/library/${library.id}`, undefined, { shallow: true });
+      await router.push(`/library/${library.id}`, undefined, { shallow: true });
     }
   };
 
@@ -72,7 +72,7 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, updateUrl 
           <Link
             className={classes.libraryIcon}
             href={`/library/${library.id}/icon/${icon.n}`}
-            onClick={(e) => handleIconModalOpen(e, icon)}
+            onClick={(e: MouseEvent<HTMLAnchorElement>) => handleIconModalOpen(e, icon)}
           >
             <CustomGridIcon gridSize={library.gridSize} path={icon.p} size={viewModes[viewMode as keyof typeof viewModes].iconSize} title={icon.n} />
             <p>{icon.n}</p>

--- a/components/IconLibrary/IconHistoryCard.tsx
+++ b/components/IconLibrary/IconHistoryCard.tsx
@@ -1,5 +1,4 @@
 import { Fragment, FunctionComponent } from 'react';
-import Link from 'next/link';
 import cx from 'clsx';
 import Avatar from '@mui/material/Avatar';
 import Chip from '@mui/material/Chip';
@@ -18,6 +17,7 @@ import { ContributorProps } from '../../interfaces/contributor';
 
 import { useData } from '../../providers/DataProvider';
 
+import Link from '../Link/Link';
 import Code from '../CodeHighlighter/CodeHighlighter';
 import CustomGridIcon from '../CustomGridIcon/CustomGridIcon';
 

--- a/components/IconLibrary/IconLibraryHistoryView.tsx
+++ b/components/IconLibrary/IconLibraryHistoryView.tsx
@@ -1,5 +1,4 @@
 import { Fragment, FunctionComponent, useEffect, useReducer, useState } from 'react';
-import Link from 'next/link';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import Button from '@mui/material/Button';
@@ -20,6 +19,7 @@ import { IconChangeRecord } from '../../interfaces/history';
 
 import Head from '../Head/Head';
 import Layout from '../Docs/Layout/Layout';
+import Link from '../Link/Link';
 import IconHistoryCard from './IconHistoryCard';
 
 import iconLibraries from '../../public/libraries/libraries.json';

--- a/components/IconLibrary/IconLibraryView.tsx
+++ b/components/IconLibrary/IconLibraryView.tsx
@@ -8,7 +8,6 @@ import {
   useState
 } from 'react';
 import { useRouter } from 'next/router';
-import Link from 'next/link';
 import cx from 'clsx';
 import Paper from '@mui/material/Paper';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -39,6 +38,7 @@ import useWindowSize from '../../hooks/useWindowSize';
 import { useData } from '../../providers/DataProvider';
 
 import Head from '../Head/Head';
+import Link from '../Link/Link';
 import LibraryMenu from './LibraryMenu';
 import LibraryViewMode from './LibraryViewMode';
 import IconGrid from '../IconGrid/IconGrid';

--- a/components/IconLibrary/LibraryMenu.module.scss
+++ b/components/IconLibrary/LibraryMenu.module.scss
@@ -6,9 +6,3 @@
     text-transform: none;
   }
 }
-
-.menuItem {
-  span {
-    display: flex;
-  }
-}

--- a/components/IconLibrary/LibraryMenu.module.scss
+++ b/components/IconLibrary/LibraryMenu.module.scss
@@ -6,3 +6,9 @@
     text-transform: none;
   }
 }
+
+.menuItem {
+  span {
+    display: flex;
+  }
+}

--- a/components/IconLibrary/LibraryMenu.tsx
+++ b/components/IconLibrary/LibraryMenu.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent, useState } from 'react';
 import getConfig from 'next/config';
-import Link from 'next/link';
 import Image from 'next/image';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
@@ -10,6 +9,8 @@ import ListItemText from '@mui/material/ListItemText';
 import ListSubheader from '@mui/material/ListSubheader';
 import Icon from '@mdi/react';
 import { mdiChevronDown } from '@mdi/js';
+
+import Link from '../Link/Link';
 
 import classes from './LibraryMenu.module.scss';
 
@@ -55,13 +56,14 @@ const LibraryMenu: FunctionComponent<LibraryMenuProps> = ({ compact = false, sel
               component={Link}
               href={`/library/${lib.id}`}
               key={lib.id}
-              onClick={() => setLibraryMenuAnchor(null)}
               selected={selectedLibrary.id === lib.id}
             >
-              <ListItemIcon>
-                <Image alt={lib.name} height={24} src={`/${lib.image}`} width={24} />
-              </ListItemIcon>
-              <ListItemText>{lib.name}</ListItemText>
+              <span onClick={() => setLibraryMenuAnchor(null)}>
+                <ListItemIcon>
+                  <Image alt={lib.name} height={24} src={`/${lib.image}`} width={24} />
+                </ListItemIcon>
+                <ListItemText>{lib.name}</ListItemText>
+              </span>
             </MenuItem>
           );
         }

--- a/components/IconLibrary/LibraryMenu.tsx
+++ b/components/IconLibrary/LibraryMenu.tsx
@@ -52,18 +52,16 @@ const LibraryMenu: FunctionComponent<LibraryMenuProps> = ({ compact = false, sel
         if (!lib.unreleased) {
           output.push(
             <MenuItem
-              classes={{ root: classes.menuItem }}
               component={Link}
               href={`/library/${lib.id}`}
               key={lib.id}
+              onClick={() => setLibraryMenuAnchor(null)}
               selected={selectedLibrary.id === lib.id}
             >
-              <span onClick={() => setLibraryMenuAnchor(null)}>
-                <ListItemIcon>
-                  <Image alt={lib.name} height={24} src={`/${lib.image}`} width={24} />
-                </ListItemIcon>
-                <ListItemText>{lib.name}</ListItemText>
-              </span>
+              <ListItemIcon>
+                <Image alt={lib.name} height={24} src={`/${lib.image}`} width={24} />
+              </ListItemIcon>
+              <ListItemText>{lib.name}</ListItemText>
             </MenuItem>
           );
         }

--- a/components/IconUsageExamples/ExampleHomeAssistant.tsx
+++ b/components/IconUsageExamples/ExampleHomeAssistant.tsx
@@ -1,10 +1,10 @@
 import { FunctionComponent } from 'react';
-import Link from 'next/link';
 import cx from 'clsx';
 import Button from '@mui/material/Button';
 import Icon from '@mdi/react';
 import { mdiArrowRight } from '@mdi/js';
 
+import Link from '../Link/Link';
 import Code from '../CodeHighlighter/CodeHighlighter';
 
 import classes from './IconUsageExamples.module.scss';

--- a/components/IconUsageExamples/ExampleReact.tsx
+++ b/components/IconUsageExamples/ExampleReact.tsx
@@ -1,10 +1,10 @@
 import { FunctionComponent } from 'react';
-import Link from 'next/link';
 import cx from 'clsx';
 import Button from '@mui/material/Button';
 import Icon from '@mdi/react';
 import { mdiArrowRight } from '@mdi/js';
 
+import Link from '../Link/Link';
 import Code from '../CodeHighlighter/CodeHighlighter';
 
 import kebabToPascal from '../../utils/helpers/kebabToPascal';

--- a/components/IconUsageExamples/ExampleVue.tsx
+++ b/components/IconUsageExamples/ExampleVue.tsx
@@ -1,10 +1,10 @@
 import { FunctionComponent } from 'react';
-import Link from 'next/link';
 import cx from 'clsx';
 import Button from '@mui/material/Button';
 import Icon from '@mdi/react';
 import { mdiArrowRight } from '@mdi/js';
 
+import Link from '../Link/Link';
 import Code from '../CodeHighlighter/CodeHighlighter';
 
 import kebabToPascal from '../../utils/helpers/kebabToPascal';

--- a/components/IconUsageExamples/ExampleWebfont.tsx
+++ b/components/IconUsageExamples/ExampleWebfont.tsx
@@ -1,11 +1,11 @@
 import { FunctionComponent } from 'react';
-import Link from 'next/link';
 import cx from 'clsx';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
 import Icon from '@mdi/react';
 import { mdiArrowRight } from '@mdi/js';
 
+import Link from '../Link/Link';
 import Code from '../CodeHighlighter/CodeHighlighter';
 
 import classes from './IconUsageExamples.module.scss';

--- a/components/IconView/IconView.tsx
+++ b/components/IconView/IconView.tsx
@@ -1,6 +1,5 @@
 import { Fragment, FunctionComponent } from 'react';
 import cx from 'clsx';
-import Link from 'next/link';
 import Paper from '@mui/material/Paper';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Chip from '@mui/material/Chip';
@@ -23,6 +22,7 @@ import { IconLibrary, IconLibraryIcon } from '../../interfaces/icons';
 import { ContributorProps } from '../../interfaces/contributor';
 
 import Head from '../Head/Head';
+import Link from '../Link/Link';
 import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
 import IconPreview from '../IconPreview/IconPreview';
 import IconUsageExamples from '../IconUsageExamples/IconUsageExamples';

--- a/components/LandingPageCard/LandingPageCard.tsx
+++ b/components/LandingPageCard/LandingPageCard.tsx
@@ -1,11 +1,11 @@
 import { CSSProperties, FunctionComponent, ReactNode } from 'react';
 import cx from 'clsx';
-import Link from 'next/link';
 import Badge, { BadgeProps } from '@mui/material/Badge';
 import Chip, { ChipTypeMap } from '@mui/material/Chip';
 import { styled } from '@mui/material/styles';
 import Icon from '@mdi/react';
 
+import Link from '../Link/Link';
 import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
 
 import classes from './LandingPageCard.module.scss';

--- a/components/LibraryCard/LibraryCard.tsx
+++ b/components/LibraryCard/LibraryCard.tsx
@@ -1,10 +1,11 @@
-import Link from 'next/link';
 import Image from 'next/image';
 import { FunctionComponent } from 'react';
 import { styled } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import Icon from '@mdi/react';
 import { mdiArrowRight } from '@mdi/js';
+
+import Link from '../Link/Link';
 
 import classes from './LibraryCard.module.scss';
 
@@ -44,7 +45,7 @@ const LibraryCard: FunctionComponent<LibraryCardProps> = ({
         {description && <p>{description}</p>}
       </div>
       {link &&
-        <Link href={link} passHref>
+        <Link href={link}>
           <LibraryButton
             endIcon={<Icon path={mdiArrowRight} size={1} />}
             fullWidth

--- a/components/Link/Link.tsx
+++ b/components/Link/Link.tsx
@@ -1,0 +1,36 @@
+import { CSSProperties, FunctionComponent, LegacyRef, MouseEvent, ReactNode, forwardRef } from 'react';
+import { useRouter } from 'next/router';
+
+// This component bypasses the need to use Next.js <Link/>
+// component because their prefetch defaults are insane.
+// See: https://nextjs.org/docs/api-reference/next/link
+
+interface LinkProps {
+  children: ReactNode | string;
+  className?: string;
+  href: string;
+  onClick?: Function;
+  rel?: string;
+  style?: CSSProperties;
+  target?: string;
+  title?: string;
+}
+
+const Link: FunctionComponent<LinkProps> = forwardRef(({ children, href, onClick, ...props }, ref: LegacyRef<HTMLAnchorElement>) => {
+  const router = useRouter();
+
+  const handleClick = async (event: MouseEvent) => {
+    event.preventDefault();
+    await onClick?.(event);
+    await router.push(href);
+  };
+
+  return (
+    <a {...props} href={href} onClick={handleClick} ref={ref}>
+      {children}
+    </a>
+  );
+});
+Link.displayName = 'Link';
+
+export default Link;

--- a/components/Link/Link.tsx
+++ b/components/Link/Link.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router';
 interface LinkProps {
   children: ReactNode | string;
   className?: string;
+  disableRouter?: boolean;
   href: string;
   onClick?: Function;
   rel?: string;
@@ -16,13 +17,16 @@ interface LinkProps {
   title?: string;
 }
 
-const Link: FunctionComponent<LinkProps> = forwardRef(({ children, href, onClick, ...props }, ref: LegacyRef<HTMLAnchorElement>) => {
+const Link: FunctionComponent<LinkProps> = forwardRef(({ children, disableRouter, href, onClick, ...props }, ref: LegacyRef<HTMLAnchorElement>) => {
   const router = useRouter();
 
   const handleClick = async (event: MouseEvent) => {
     event.preventDefault();
     await onClick?.(event);
-    await router.push(href);
+
+    if (!disableRouter) {
+      await router.push(href);
+    }
   };
 
   return (

--- a/components/MDIWelcome/MDIWelcome.tsx
+++ b/components/MDIWelcome/MDIWelcome.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from 'react';
-import Link from 'next/link';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -9,6 +8,8 @@ import Icon from '@mdi/react';
 import { mdiHandWaveOutline } from '@mdi/js';
 
 import useWindowSize from '../../hooks/useWindowSize';
+
+import Link from '../Link/Link';
 
 import classes from './MDIWelcome.module.scss';
 

--- a/components/SiteSearch/SiteSearch.tsx
+++ b/components/SiteSearch/SiteSearch.tsx
@@ -4,7 +4,6 @@ import Autocomplete from '@mui/material/Autocomplete';
 import Popper, { PopperProps } from '@mui/material/Popper';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
-import Link from 'next/link';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -14,6 +13,7 @@ import uFuzzy from '@leeoniya/ufuzzy';
 import Icon from '@mdi/react';
 import { mdiAlertOutline, mdiBookOpenPageVariantOutline, mdiCreation, mdiDotsHorizontalCircleOutline, mdiMagnify } from '@mdi/js';
 
+import Link from '../Link/Link';
 import CustomGridIcon from '../CustomGridIcon/CustomGridIcon';
 
 import { useData } from '../../providers/DataProvider';

--- a/pages/brand-guidelines.tsx
+++ b/pages/brand-guidelines.tsx
@@ -67,6 +67,7 @@ const PostPage: NextPage = () => {
           <p>The Pictogrammers logo is the central visual identity for the Pictogrammers group. The monogram was created by <Link href='/contributor/Templarian'>Austin Andrews</Link> in 2020. The following year, the wordmark was added by <Link href='/contributor/mririgoyen'>Michael Irigoyen</Link>, completing the logo.</p>
           <Button
             className={classes.button}
+            component={Link}
             endIcon={<Icon path={mdiArrowDown} size={1} />}
             href='/pictogrammers-brand-assets.zip'
             variant='contained'

--- a/pages/brand-guidelines.tsx
+++ b/pages/brand-guidelines.tsx
@@ -1,6 +1,5 @@
 import { Fragment } from 'react';
 import { NextPage } from 'next';
-import Link from 'next/link';
 import Image from 'next/image';
 import cx from 'clsx';
 import Button from '@mui/material/Button';
@@ -10,6 +9,7 @@ import { mdiArrowDown } from '@mdi/js';
 import Head from '../components/Head/Head';
 import Layout from '../components/Docs/Layout/Layout';
 import Heading from '../components/Docs/Heading';
+import Link from '../components/Link/Link';
 
 import PictogrammersLogoSvg from '../assets/brand/logos/pictogrammers-full.svg';
 import MDILogoSvg from '../assets/libraries/mdi.svg';
@@ -65,15 +65,14 @@ const PostPage: NextPage = () => {
           <Heading2>Logo</Heading2>
           <PictogrammersLogoSvg className={classes.pictogrammers} />
           <p>The Pictogrammers logo is the central visual identity for the Pictogrammers group. The monogram was created by <Link href='/contributor/Templarian'>Austin Andrews</Link> in 2020. The following year, the wordmark was added by <Link href='/contributor/mririgoyen'>Michael Irigoyen</Link>, completing the logo.</p>
-          <Link href='/pictogrammers-brand-assets.zip' passHref>
-            <Button
-              className={classes.button}
-              endIcon={<Icon path={mdiArrowDown} size={1} />}
-              variant='contained'
-            >
-              Download Logo Assets
-            </Button>
-          </Link>                
+          <Button
+            className={classes.button}
+            endIcon={<Icon path={mdiArrowDown} size={1} />}
+            href='/pictogrammers-brand-assets.zip'
+            variant='contained'
+          >
+            Download Logo Assets
+          </Button>              
         </section>
 
         <section>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,12 @@
 import { NextPage } from 'next';
 import getConfig from 'next/config';
-import Link from 'next/link';
 import { Fragment } from 'react';
 import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
 import Icon from '@mdi/react';
 import { mdiCrowd } from '@mdi/js';
 
+import Link from '../components/Link/Link';
 import Hero from '../components/Hero/Hero';
 import HomeSection from '../components/HomeSection/HomeSection';
 import LibraryCard from '../components/LibraryCard/LibraryCard';
@@ -104,7 +104,7 @@ const Home: NextPage = () => {
         <HomeSection id='join' title='Join Us'>
           <div className={classes.join}>
             <p>
-              If you&apos;re looking to get involved with the Pictogrammers, there are many ways you can help! You can tackle <Link href='/docs/contribute'>issues and icon requests</Link> on one of our libraries. You can <a href='https://github.com/Pictogrammers/pictogrammers.com/tree/main/docs'>write and update documentation</a> to help those looking to get started. Interested in writing an integration we don&apos;t have... <Link href='/docs/contribute/third-party'>Go for it!</Link>
+              If you&apos;re looking to get involved with the Pictogrammers, there are many ways you can help! You can tackle <Link href='/docs/contribute'>issues and icon requests</Link> on one of our libraries. You can <Link href='https://github.com/Pictogrammers/pictogrammers.com/tree/main/docs'>write and update documentation</Link> to help those looking to get started. Interested in writing an integration we don&apos;t have... <Link href='/docs/contribute/third-party'>Go for it!</Link>
               <br />
               <br />
               If you have any questions about how you can make an impact, reach out to us on <a href='https://fosstodon.org/@pictogrammers' rel='me'>Mastodon</a> or open a <a href='https://github.com/Templarian/MaterialDesign/issues/new?assignees=&labels=Question&template=6_question.yml'>GitHub issue</a>. We look forward to meeting you!

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -107,7 +107,7 @@ const Home: NextPage = () => {
               If you&apos;re looking to get involved with the Pictogrammers, there are many ways you can help! You can tackle <Link href='/docs/contribute'>issues and icon requests</Link> on one of our libraries. You can <Link href='https://github.com/Pictogrammers/pictogrammers.com/tree/main/docs'>write and update documentation</Link> to help those looking to get started. Interested in writing an integration we don&apos;t have... <Link href='/docs/contribute/third-party'>Go for it!</Link>
               <br />
               <br />
-              If you have any questions about how you can make an impact, reach out to us on <a href='https://fosstodon.org/@pictogrammers' rel='me'>Mastodon</a> or open a <a href='https://github.com/Templarian/MaterialDesign/issues/new?assignees=&labels=Question&template=6_question.yml'>GitHub issue</a>. We look forward to meeting you!
+              If you have any questions about how you can make an impact, reach out to us on <Link href='https://fosstodon.org/@pictogrammers' rel='me'>Mastodon</Link> or open a <Link href='https://github.com/Templarian/MaterialDesign/issues/new?assignees=&labels=Question&template=6_question.yml'>GitHub issue</Link>. We look forward to meeting you!
             </p>
             <Icon
               className={classes.crowd}

--- a/pages/tools/github.tsx
+++ b/pages/tools/github.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { NextPage } from 'next';
-import Link from 'next/link';
 
+import Link from '../../components/Link/Link';
 import Head from '../../components/Head/Head';
 import Layout from '../../components/Docs/Layout/Layout';
 import CodeHighlighter from '../../components/CodeHighlighter/CodeHighlighter';

--- a/pages/tools/pixel-editor.tsx
+++ b/pages/tools/pixel-editor.tsx
@@ -1,6 +1,5 @@
 import { Fragment, useState } from 'react';
 import { NextPage } from 'next';
-import Link from 'next/link';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import Icon from '@mdi/react';
@@ -9,6 +8,7 @@ import { mdiClipboard } from '@mdi/js';
 
 import useCopyToClipboard from '../../hooks/useCopyToClipboard';
 
+import Link from '../../components/Link/Link';
 import Head from '../../components/Head/Head';
 import Layout from '../../components/Docs/Layout/Layout';
 


### PR DESCRIPTION
## What's Changed

Replaced the Next.js `Link` component with a custom component that calls the router API `onClick` only. No prefetching.

## Why?

Shortly after launch of the new site, and after we started to redirect traffic to it from the old `materialdesignicons.com` site, the server became inundated with HTTP requests, bringing the server to its knees. After careful research, we believe this implementation detail was the root cause of the problem.

## Background

The Next.js `<Link>` component is incredibly opinionated and, in our case, server breaking. To navigate the local site quickly utilizing the Next.js router, use of the Link component, or individual `router` calls is required. However, the `Link` component has this feature that cannot be disabled fully:

> `prefetch` - Prefetch the page in the background. Defaults to `true`. Any `<Link />` that is in the viewport (initially or through scroll) will be preloaded. Prefetch can be disabled by passing `prefetch={false}`. When `prefetch` is set to `false`, prefetching will still occur on hover. Pages using [Static Generation](https://nextjs.org/docs/basic-features/data-fetching/get-static-props) will preload `JSON` files with the data for faster page transitions. Prefetching is only enabled in production.

Source: https://nextjs.org/docs/api-reference/next/link

The `prefetch` option cannot be set globally. Even if we added `prefetch={false}` to all links, hovering still causes a prefetch to happen, regardless of that setting. For our Icon Library view, having 30+ icons on screen at one time means 30 extra HTTP requests. Scroll quickly and suddenly one user can trigger thousands of calls in a very, very short time period.

---

Related issue: https://github.com/Pictogrammers/pictogrammers.com/issues/25