### PR TITLE
More Advanced Export Improvements

### DIFF
--- a/components/ColorPicker/ColorPicker.module.scss
+++ b/components/ColorPicker/ColorPicker.module.scss
@@ -1,5 +1,9 @@
 .root {
   position: relative;
+
+  div[title='Transparent'] {
+    background: repeating-conic-gradient(hsl(var(--medium-grey) / 50%) 0% 25%, transparent 0% 50%) !important;
+  }
 }
 
 .swatch {

--- a/components/ColorPicker/ColorPicker.module.scss
+++ b/components/ColorPicker/ColorPicker.module.scss
@@ -4,6 +4,13 @@
   div[title='Transparent'] {
     background: repeating-conic-gradient(hsl(var(--medium-grey) / 50%) 0% 25%, transparent 0% 50%) !important;
   }
+
+  div[class='flexbox-fix'] {
+    input {
+      text-align: center;
+      width: 100% !important;
+    }
+  }
 }
 
 .swatch {

--- a/components/ColorPicker/ColorPicker.tsx
+++ b/components/ColorPicker/ColorPicker.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, useCallback, useRef, useState } from 'react';
-import { ChromePicker, ColorChangeHandler } from 'react-color';
+import { SketchPicker } from 'react-color';
 import FormControlLabel from '@mui/material/FormControlLabel';
 
 import useClickOutside from '../../hooks/useClickOutside';
@@ -24,8 +24,6 @@ const PopoverPicker: FunctionComponent<ColorPickerProps> = ({ color, label, onCh
   const close = useCallback(() => toggleVisibility(false), []);
   useClickOutside(popover, close);
 
-  console.log(label, color);
-
   return (
     <div className={classes.root}>
       <FormControlLabel
@@ -43,7 +41,31 @@ const PopoverPicker: FunctionComponent<ColorPickerProps> = ({ color, label, onCh
       />
       {isOpen && (
         <div className={classes.popover} ref={popover}>
-          <ChromePicker color={color} onChange={onChange} />
+          <SketchPicker
+            color={color}
+            onChange={onChange}
+            presetColors={[
+              '#D0021B',
+              '#F5A623',
+              '#F8E71C',
+              '#8B572A',
+              '#7ED321',
+              '#417505',
+              '#BD10E0',
+              '#9013FE',
+              '#530066',
+              '#4A90E2',
+              '#50E3C2',
+              '#3B5F68',
+              '#B8E986',
+              '#000000',
+              '#4A4A4A',
+              '#9B9B9B',
+              '#FFFFFF',
+              { color: 'TRANSPARENT', title: 'Transparent' }
+            ]}
+            width='225px'
+          />
         </div>
       )}
     </div>

--- a/components/IconCustomizer/IconCustomizer.module.scss
+++ b/components/IconCustomizer/IconCustomizer.module.scss
@@ -67,14 +67,10 @@
 }
 
 .controls {
-  column-gap: 1rem;
+  align-items: center;
   display: flex;
+  gap: 1.5rem;
   margin-right: 1rem;
-
-  & > svg {
-    margin-right: .5rem;
-    margin-top: .15rem;
-  }
 
   & > span {
     flex: 1;

--- a/components/IconCustomizer/IconCustomizer.tsx
+++ b/components/IconCustomizer/IconCustomizer.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent, FunctionComponent, useState } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ColorResult } from 'react-color';
 import Button from '@mui/material/Button';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
 import Slider from '@mui/material/Slider';
+import Input from '@mui/material/Input';
 import Tooltip from '@mui/material/Tooltip';
 import Icon from '@mdi/react';
 import {
@@ -19,7 +19,6 @@ import {
 import IconPreview from '../IconPreview/IconPreview';
 import ColorPicker from '../ColorPicker/ColorPicker';
 
-import useWindowSize from '../../hooks/useWindowSize';
 import { useAnalytics } from 'use-analytics';
 
 import { IconCustomizationProps, IconLibrary, IconLibraryIcon } from '../../interfaces/icons';
@@ -46,11 +45,10 @@ const IconCustomizer: FunctionComponent<IconCustomizerProps> = ({ gridSize, icon
 
   const maxIconSize = 256;
   const minIconSize = gridSize / 2;
-  const maxCornerRadius = minIconSize / 100;
 
   const { track } = useAnalytics();
-  const windowSize = useWindowSize();
-  const isMobileWidth = windowSize.width <= parseInt(classes['mobile-width']);
+
+  const clamp = (number: number, min: number, max: number) => Math.max(min, Math.min(number, max));
 
   const calculateTransform = () => {
     const transforms = [];
@@ -60,7 +58,8 @@ const IconCustomizer: FunctionComponent<IconCustomizerProps> = ({ gridSize, icon
     transforms.push(`rotate(${customizations.rotate}, ${centerPoint}, ${centerPoint})`);
 
     // Handle padding and flipping
-    const scale = 1 - (customizations.padding / maxIconSize);
+    const dpPixelRatio = 28.571;
+    const scale = 1 - ((customizations.padding * dpPixelRatio) / maxIconSize);
     const translate = (1 - scale) * (centerPoint / scale);
     transforms.push(`scale(${(customizations.flipX ? scale * -1 : scale).toFixed(3)} ${(customizations.flipY ? scale * -1 : scale).toFixed(3)})`);
     transforms.push(`translate(${(customizations.flipX ? (translate * -1) - gridSize : translate).toFixed(3)} ${(customizations.flipY ? (translate * -1) - gridSize : translate).toFixed(3)})`);
@@ -72,14 +71,14 @@ const IconCustomizer: FunctionComponent<IconCustomizerProps> = ({ gridSize, icon
     <svg viewBox={`0 0 ${gridSize} ${gridSize}`} xmlns='http://www.w3.org/2000/svg'>
       <title>{icon.n}</title>
       <rect
-        fill={`rgb(${customizations.bgColor.r} ${customizations.bgColor.g} ${customizations.bgColor.b} / ${(customizations.bgColor.a || 0) * 100}%)`}
+        fill={`rgb(${customizations.bgColor.r} ${customizations.bgColor.g} ${customizations.bgColor.b} / ${customizations.bgColor.a * 100}%)`}
         height={gridSize}
-        rx={customizations.cornerRadius * maxCornerRadius}
-        ry={customizations.cornerRadius * maxCornerRadius}
+        rx={customizations.cornerRadius}
+        ry={customizations.cornerRadius}
         width={gridSize}
       />
       <path
-        fill={`rgb(${customizations.fgColor.r} ${customizations.fgColor.g} ${customizations.fgColor.b} / ${(customizations.fgColor.a || 1) * 100}%)`}
+        fill={`rgb(${customizations.fgColor.r} ${customizations.fgColor.g} ${customizations.fgColor.b} / ${customizations.fgColor.a * 100}%)`}
         d={icon.p}
         transform={calculateTransform()}
       />
@@ -140,11 +139,6 @@ const IconCustomizer: FunctionComponent<IconCustomizerProps> = ({ gridSize, icon
                 <Icon path={mdiResize} size={1} />
                 <Slider
                   aria-labelledby='size-controls'
-                  marks={!isMobileWidth && [
-                    { label: '48px', value: 48 },
-                    { label: '128px', value: 128 },
-                    { label: '256px', value: 256 }
-                  ]}
                   max={maxIconSize}
                   min={minIconSize}
                   onChange={(e, value) => setCustomizations({ ...customizations, size: Number(value) })}
@@ -152,6 +146,32 @@ const IconCustomizer: FunctionComponent<IconCustomizerProps> = ({ gridSize, icon
                   value={customizations.size}
                   valueLabelDisplay='auto'
                   valueLabelFormat={(value) => `${value}px`}
+                />
+                <Input
+                  endAdornment='px'  
+                  inputProps={{
+                    'aria-labelledby': 'size-controls',
+                    inputMode: 'numeric',
+                    max: maxIconSize,
+                    min: minIconSize,
+                    pattern: '[0-9]*',
+                    step: 10,
+                    type: 'text'
+                  }}
+                  onBlur={(e) => {
+                    if (Number(e.target.value) < minIconSize) {
+                      setCustomizations({ ...customizations, size: minIconSize });
+                    }
+                  }}
+                  onChange={(e) => {
+                    const newValue = Number(e.target.value);
+                    if (isNaN(newValue)) {
+                      return;
+                    }
+                    setCustomizations({ ...customizations, size: clamp(newValue, 0, maxIconSize) });
+                  }}
+                  size='small'
+                  value={customizations.size}
                 />
               </div>
             </div>
@@ -161,12 +181,33 @@ const IconCustomizer: FunctionComponent<IconCustomizerProps> = ({ gridSize, icon
                 <Icon path={mdiStretchToPageOutline} size={1} />
                 <Slider
                   aria-labelledby='padding-controls'
-                  max={100}
+                  max={5}
                   onChange={(e, value) => setCustomizations({ ...customizations, padding: Number(value) })}
-                  step={2}
+                  step={1}
                   value={customizations.padding}
                   valueLabelDisplay='auto'
-                  valueLabelFormat={(value) => `${value}px`}
+                  valueLabelFormat={(value) => `${value}dp`}
+                />
+                <Input
+                  endAdornment='dp'
+                  inputProps={{
+                    'aria-labelledby': 'padding-controls',
+                    inputMode: 'numeric',
+                    max: 5,
+                    min: 0,
+                    pattern: '[0-9]*',
+                    step: 1,
+                    type: 'text'
+                  }}
+                  onChange={(e) => {
+                    const newValue = Number(e.target.value);
+                    if (isNaN(newValue)) {
+                      return;
+                    }
+                    setCustomizations({ ...customizations, padding: clamp(newValue, 0, 5) });
+                  }}
+                  size='small'
+                  value={customizations.padding}
                 />
               </div>
             </div>
@@ -178,16 +219,32 @@ const IconCustomizer: FunctionComponent<IconCustomizerProps> = ({ gridSize, icon
                 <Icon path={mdiReload} size={1} />
                 <Slider
                   aria-labelledby='rotate-controls'
-                  marks={!isMobileWidth && [
-                    { label: '90°', value: 90 },
-                    { label: '180°', value: 180 },
-                    { label: '270°', value: 270 }
-                  ]}
                   max={360}
                   onChange={(e, value) => setCustomizations({ ...customizations, rotate: Number(value) })}
                   value={customizations.rotate}
                   valueLabelDisplay='auto'
                   valueLabelFormat={(value) => `${value}°`}
+                />
+                <Input
+                  endAdornment='°'
+                  inputProps={{
+                    'aria-labelledby': 'rotate-controls',
+                    inputMode: 'numeric',
+                    max: 360,
+                    min: 0,
+                    pattern: '[0-9]*',
+                    step: 10,
+                    type: 'text'
+                  }}
+                  onChange={(e) => {
+                    const newValue = Number(e.target.value);
+                    if (isNaN(newValue)) {
+                      return;
+                    }
+                    setCustomizations({ ...customizations, rotate: clamp(newValue, 0, 360) });
+                  }}
+                  size='small'
+                  value={customizations.rotate}
                 />
               </div>
             </div>
@@ -203,12 +260,33 @@ const IconCustomizer: FunctionComponent<IconCustomizerProps> = ({ gridSize, icon
                 <Slider
                   aria-labelledby='radius-controls'
                   disabled={customizations.bgColor.a < 0.01}
-                  max={100}
+                  max={12}
                   onChange={(e, value) => setCustomizations({ ...customizations, cornerRadius: Number(value) })}
-                  step={10}
+                  step={1}
                   value={customizations.cornerRadius}
                   valueLabelDisplay='auto'
-                  valueLabelFormat={(value) => `${value}%`}
+                  valueLabelFormat={(value) => `${value}dp`}
+                />
+                <Input
+                  endAdornment='dp'
+                  inputProps={{
+                    'aria-labelledby': 'radius-controls',
+                    inputMode: 'numeric',
+                    max: minIconSize,
+                    min: 0,
+                    pattern: '[0-9]*',
+                    step: 1,
+                    type: 'text'
+                  }}
+                  onChange={(e) => {
+                    const newValue = Number(e.target.value);
+                    if (isNaN(newValue)) {
+                      return;
+                    }
+                    setCustomizations({ ...customizations, cornerRadius: clamp(newValue, 0, minIconSize) });
+                  }}
+                  size='small'
+                  value={customizations.cornerRadius}
                 />
               </div>
             </div>
@@ -230,10 +308,10 @@ const IconCustomizer: FunctionComponent<IconCustomizerProps> = ({ gridSize, icon
       <Button
         onClick={downloadCustomIcon}
         startIcon={<Icon path={mdiDownload} size={1} />}
-        sx={{ margin: '0 1rem', minWidth: '250px' }}
+        sx={{ margin: '0 1rem', minWidth: '200px' }}
         variant='contained'
       >
-        Download PNG ({customizations.size}x{customizations.size})
+        Download PNG
       </Button>
     </div>
   );


### PR DESCRIPTION
Addresses #37.

- Adjusts color pickers to include 18 sample color swatches. Additionally puts both the Hex and RGBA boxes on the same interface for easier manual color code entering.
![Screenshot 2023-01-30 at 7 46 17 PM](https://user-images.githubusercontent.com/1015040/215638525-dce8ed39-6655-479d-94d7-fcf465dbdee6.png)
- Adjusts the Padding and Corner Radius to use design point (dp) units instead of incorrect pixel units (padding) and arbitrary percentages (corner radius).
- Adds manual entry input fields next to each slider.
![Screenshot 2023-01-30 at 7 41 52 PM](https://user-images.githubusercontent.com/1015040/215637806-7c371cd7-c5ab-4a8c-8293-e3156dc5fe0c.png)
