### PR TITLE
Support deprecated icons and showing related icons on the icon pages

### DIFF
--- a/components/IconCustomizer/IconCustomizer.module.scss
+++ b/components/IconCustomizer/IconCustomizer.module.scss
@@ -18,6 +18,7 @@
 
 .preview {
   margin-bottom: 4rem;
+  margin-top: .9rem;
 }
 
 .customize {

--- a/components/IconGrid/IconGrid.module.scss
+++ b/components/IconGrid/IconGrid.module.scss
@@ -119,4 +119,19 @@
     margin: 0;
     overflow-wrap: break-word;
   }
+
+  &.deprecated {
+    background-color: hsl(var(--red) / 5%);
+    outline: 1px solid hsl(var(--red) / 10%);
+
+    &:hover {
+      background-color: hsl(var(--red) / 10%);
+      outline: 1px solid hsl(var(--red) / 15%);
+    }
+
+    &:focus {
+      background-color: hsl(var(--red) / 15%);
+      outline: 1px solid hsl(var(--red) / 20%);
+    }
+  }
 }

--- a/components/IconGrid/IconGrid.tsx
+++ b/components/IconGrid/IconGrid.tsx
@@ -3,6 +3,7 @@ import cx from 'clsx';
 import { useRouter } from 'next/router';
 import { VirtuosoGrid } from 'react-virtuoso';
 import Dialog from '@mui/material/Dialog';
+import Tooltip from '@mui/material/Tooltip';
 
 import useCategories, { CategoryProps } from '../../hooks/useCategories';
 import useWindowSize from '../../hooks/useWindowSize';
@@ -11,6 +12,7 @@ import Link from '../Link/Link';
 import { viewModes } from '../IconLibrary/LibraryViewMode';
 import IconView from '../IconView/IconView';
 import CustomGridIcon from '../CustomGridIcon/CustomGridIcon';
+import ConditionalWrapper from '../ConditionalWrapper/ConditionalWrapper';
 
 import { IconLibrary, IconLibraryIcon } from '../../interfaces/icons';
 
@@ -70,15 +72,26 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, modalHook,
         data={icons}
         listClassName={cx(classes.library, classes[viewMode])}
         itemContent={(index, icon: IconLibraryIcon) => (
-          <Link
-            className={classes.libraryIcon}
-            disableRouter
-            href={`/library/${library.id}/icon/${icon.n}`}
-            onClick={(e: MouseEvent<HTMLAnchorElement>) => handleIconModalOpen(e, icon)}
+          <ConditionalWrapper
+            condition={!!icon.d}
+            wrapper={(children: any) => (
+              <Tooltip arrow placement='top' title={<Fragment><strong>Icon Deprecated</strong><br/>Click for more info.</Fragment>}>
+                {children}
+              </Tooltip>
+            )}
           >
-            <CustomGridIcon gridSize={library.gridSize} path={icon.p} size={viewModes[viewMode as keyof typeof viewModes].iconSize} title={icon.n} />
-            <p>{icon.n}</p>
-          </Link>
+            <Link
+              className={cx(classes.libraryIcon, {
+                [classes.deprecated]: !!icon.d
+              })}
+              disableRouter
+              href={`/library/${library.id}/icon/${icon.n}`}
+              onClick={(e: MouseEvent<HTMLAnchorElement>) => handleIconModalOpen(e, icon)}
+            >
+              <CustomGridIcon gridSize={library.gridSize} path={icon.p} size={viewModes[viewMode as keyof typeof viewModes].iconSize} title={icon.n} />
+              <p>{icon.n}</p>
+            </Link>
+          </ConditionalWrapper>
         )}
         overscan={300}
         totalCount={icons.length}

--- a/components/IconLibrary/IconLibraryView.module.scss
+++ b/components/IconLibrary/IconLibraryView.module.scss
@@ -75,8 +75,12 @@
 .sidebar {
   background-color: hsl(var(--light-grey) / 30%);
   flex: 1;
-  max-width: 210px;
+  max-width: 225px;
   padding: 1rem 0;
+
+  svg {
+    margin-left: -.5rem;
+  }
 }
 
 .infoGrid {

--- a/components/IconLibrary/LibraryMenu.module.scss
+++ b/components/IconLibrary/LibraryMenu.module.scss
@@ -2,7 +2,7 @@
   p {
     color: hsl(var(--dark-grey));
     font-size: 1.2rem;
-    margin: 0 0 0 .5rem;
+    margin: 0 0 0 .75rem;
     text-transform: none;
   }
 }

--- a/components/IconView/IconView.module.scss
+++ b/components/IconView/IconView.module.scss
@@ -12,7 +12,8 @@
   padding: 2rem;
   position: relative;
 
-  .infoBar {
+  .infoBar,
+  .deprecated {
     margin: 0 -2rem;
   }
 
@@ -97,6 +98,10 @@
   }
 }
 
+.deprecated {
+  padding: .5rem 2rem;
+}
+
 .usage {
   align-items: center;
   display: flex;
@@ -129,6 +134,18 @@
 
   a {
     text-decoration: none;
+  }
+}
+
+.related {
+  h2 {
+    background-color: hsl(var(--dark-cyan));
+    color: hsl(var(--white));
+    font-size: .8rem;
+    letter-spacing: .2rem;
+    margin: 3rem -2rem 2rem;
+    padding: .3rem 2rem;
+    text-transform: uppercase;
   }
 }
 

--- a/components/IconView/IconView.tsx
+++ b/components/IconView/IconView.tsx
@@ -5,6 +5,7 @@ import Paper from '@mui/material/Paper';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Chip from '@mui/material/Chip';
 import Avatar from '@mui/material/Avatar';
+import Alert from '@mui/material/Alert';
 import Tooltip from '@mui/material/Tooltip';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
@@ -31,6 +32,7 @@ import IconPreview from '../IconPreview/IconPreview';
 import IconUsageExamples from '../IconUsageExamples/IconUsageExamples';
 import IconDownloadMenu from './IconDownloadMenu';
 import IconCustomizer from '../IconCustomizer/IconCustomizer';
+import IconGrid from '../IconGrid/IconGrid';
 import CarbonAd from '../CarbonAd/CarbonAd';
 
 import useCopyToClipboard from '../../hooks/useCopyToClipboard';
@@ -218,6 +220,11 @@ const IconView: FunctionComponent<IconViewProps> = ({ icon, libraryInfo, onClose
             </div>
           ) : (
             <Fragment>
+              {icon.d && (
+                <Alert classes={{ root: classes.deprecated }} severity='error'>
+                  This icon has been deprecated and will be removed in an upcoming release. New use of this icon is highly discouraged. If you are currently using this icon, please make plans to replace it before upgrading to a newer version of the library.
+                </Alert>
+              )}
               <div className={classes.usage}>
                 <div className={classes.preview}>
                   <IconPreview
@@ -263,6 +270,12 @@ const IconView: FunctionComponent<IconViewProps> = ({ icon, libraryInfo, onClose
                   </Tooltip>
                 </div>
               </div>
+              {!!icon.relatedIcons?.length && (
+                <div className={classes.related}>
+                  <h2>Related Icons</h2>
+                  <IconGrid icons={icon.relatedIcons} library={libraryInfo} updateUrl={false} viewMode='comfortable' />
+                </div>
+              )}
             </Fragment>
           )}
         </Fragment>

--- a/components/SiteSearch/SiteSearch.module.scss
+++ b/components/SiteSearch/SiteSearch.module.scss
@@ -32,6 +32,24 @@
 
     svg {
       color: hsl(var(--primary-color));
+    }
+  }
+
+  .deprecated {
+    color: hsl(var(--red));
+
+    svg {
+      color: hsl(var(--red));
+    }
+  }
+
+  .new,
+  .deprecated {
+    align-items: center;
+    display: inline-flex;
+    justify-content: center;
+
+    svg {
       margin: 0 -7px 0 -10px;
     }
   }
@@ -42,7 +60,8 @@
 
   .subtext {
     color: hsl(var(--grey));
-    display: block;
+    column-gap: .2rem;
+    display: flex;
     font-size: .8rem;
   }
 }

--- a/components/SiteSearch/SiteSearch.tsx
+++ b/components/SiteSearch/SiteSearch.tsx
@@ -13,7 +13,7 @@ import ListSubheader from '@mui/material/ListSubheader';
 import Avatar from '@mui/material/Avatar';
 import uFuzzy from '@leeoniya/ufuzzy';
 import Icon from '@mdi/react';
-import { mdiAlertOutline, mdiBookOpenPageVariantOutline, mdiCreation, mdiDotsHorizontalCircleOutline, mdiMagnify } from '@mdi/js';
+import { mdiAlertOctagonOutline, mdiAlertOutline, mdiBookOpenPageVariantOutline, mdiCreation, mdiDotsHorizontalCircleOutline, mdiMagnify } from '@mdi/js';
 
 import Link from '../Link/Link';
 import CustomGridIcon from '../CustomGridIcon/CustomGridIcon';
@@ -192,6 +192,7 @@ const SiteSearch: FunctionComponent = () => {
                   const title = isLibrary ? result.n : option.id === 'docs' ? result.title : result.name;
                   const icon = isLibrary ? result.p : mdiBookOpenPageVariantOutline;
                   const isNew = isLibrary && option.libraryInfo?.version === result.v;
+                  const isDeprecated = isLibrary && result.d;
                   return (
                     <ListItem key={result.cp || result.slug} sx={{ padding: 0 }}>
                       <ListItemButton component={Link} href={link} onClick={closeSearchResults}>
@@ -221,7 +222,14 @@ const SiteSearch: FunctionComponent = () => {
                         <ListItemText>
                           {title}
                           {!!isLibrary ? (
-                            <span className={classes.subtext}>{isNew ? <strong className={classes.new}><Icon path={mdiCreation} size={.5} />New! </strong> : ''}Added in v{result.v}</span>
+                            <span className={classes.subtext}>
+                              {isDeprecated ? (
+                                <strong className={classes.deprecated}><Icon path={mdiAlertOctagonOutline} size={.5} />DEPRECATED </strong>
+                              ) : isNew ? (
+                                <strong className={classes.new}><Icon path={mdiCreation} size={.5} />New! </strong>
+                              ) : ''}
+                              Added in v{result.v}
+                            </span>
                           ) : option.id !== 'contributors' ? (
                             <span className={classes.subtext}>{result.library ? `${result.library} • ` : ''}{result.category}</span>
                           ) : (

--- a/hooks/useIcons.ts
+++ b/hooks/useIcons.ts
@@ -38,6 +38,8 @@ const useIcons = (libraryId: string, filter: FilterProps) => {
         case 'category':
           const categoryId = iconTags.findIndex((cat: CategoryProps) => cat.slug === filter.category);
           return output.filter((icon: IconLibraryIcon) => icon.t.includes(categoryId));
+        case 'deprecated':
+          return output.filter((icon: IconLibraryIcon) => icon.d);
         case 'version':
           return output.filter((icon: IconLibraryIcon) => icon.v === filter.version);
         case 'term':

--- a/interfaces/icons.ts
+++ b/interfaces/icons.ts
@@ -25,10 +25,13 @@ export interface IconLibrary {
 export interface IconLibraryIcon {
   a: string; // Author
   al: string[]; // Aliases
+  b: string; // Base Icon Name
   categories?: CategoryProps[]; // Categories
   cp: string; // Codepoint
+  d: boolean; // Deprecated
   n: string; // Name
   p: string; // Path
+  relatedIcons?: IconLibraryIcon[]; // Related Icons
   st: string[]; // Search Terms (Combined Index)
   t: string[]; // Tags
   v: string; // Version

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -63,7 +63,9 @@ const theme = createTheme({
           color: 'black'
         },
         tooltip: {
-          backgroundColor: 'black'
+          backgroundColor: 'black',
+          fontSize: '.8rem',
+          textAlign: 'center'
         }
       }
     }

--- a/pages/libraries.tsx
+++ b/pages/libraries.tsx
@@ -2,8 +2,10 @@ import { NextPage } from 'next';
 import getConfig from 'next/config';
 import ExportedImage from 'next-image-export-optimizer';
 import Paper from '@mui/material/Paper';
-import dayjs from 'dayjs';
 import { mdiFormatFont, mdiRobotExcited } from '@mdi/js';
+import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+dayjs.extend(advancedFormat);
 
 import Head from '../components/Head/Head';
 import LandingPageHeading from '../components/LandingPageHeading/LandingPageHeading';
@@ -35,7 +37,7 @@ const LibraryCard = (props: { library: LibraryProps, type: string }) => {
         label: library.unreleased ? 'Coming Soon!' : `${libraryStats.count} Icons`
       }}
       color={`--${library.id}-color`}
-      description={library.unreleased ? 'Unreleased' : `v${libraryStats.version} • Released on ${dayjs(libraryStats.date).format('MMM DD, YYYY')}`}
+      description={library.unreleased ? 'Unreleased' : `v${libraryStats.version} • Released on ${dayjs(libraryStats.date).format('MMM Do, YYYY')}`}
       disabled={!!library.unreleased}
       headerElement='h3'
       href={library.unreleased ? undefined : `/library/${library.id}`}

--- a/pages/library/[...slug].tsx
+++ b/pages/library/[...slug].tsx
@@ -57,8 +57,8 @@ export const getStaticProps: GetStaticProps = async (context) => {
         }
       };
 
-      if (viewType && viewName) {
-        output.props[viewType as keyof typeof output.props] = viewName;
+      if (viewType) {
+        output.props[viewType as keyof typeof output.props] = viewName || true;
       }
 
       return output;

--- a/scripts/getIconLibraries.mjs
+++ b/scripts/getIconLibraries.mjs
@@ -46,7 +46,10 @@ const getIconLibraries = async (contributors = []) => {
       const {
         aliases,
         author,
+        baseIconId,
         codepoint,
+        deprecated,
+        id,
         name,
         tags,
         version
@@ -61,6 +64,17 @@ const getIconLibraries = async (contributors = []) => {
 
       // Map author to their ID
       thisIcon.a = contributors.find((c) => c.name === author)?.id;
+
+      // Map baseIconId to its name. If it doesn't have a baseIconId
+      // or the baseIconId is the same as itself, omit it to limit the
+      // overall JSON file size.
+      thisIcon.b = baseIconId !== id ? libraryIcons.find((i) => i.id === baseIconId)?.name : undefined;
+
+      // Only set the deprecated flag if it's true
+      if (deprecated) {
+        thisIcon.d = true;
+        output.d++;
+      }
 
       // Simplify tags
       const tagIds = tags.map((tag) => {
@@ -83,8 +97,9 @@ const getIconLibraries = async (contributors = []) => {
       output.i.push(thisIcon);
       return output;
     }, Promise.resolve({
-      d: releasedOn, // Release Date
+      d: 0, // Deprecated Icon Count
       i: [], // Icons
+      r: releasedOn, // Release Date
       t: [], // Tags
       v: libraryVersion // Version
     }));
@@ -99,7 +114,8 @@ const getIconLibraries = async (contributors = []) => {
 
     output[libraryId] = {
       count: processedLibraries[libraryId].i.length,
-      date: processedLibraries[libraryId].d.split('.')[0],
+      date: processedLibraries[libraryId].r.split('.')[0],
+      deprecatedCount: processedLibraries[libraryId].d,
       version: processedLibraries[libraryId].v
     };
     return output;


### PR DESCRIPTION
Fixes #11.

## Deprecated Icons Support
- Adds a "Deprecated Icons" filter to the Icon Library view (when there is at least 1 deprecated icon to show).
- Indicates icons are deprecated with a red background and tooltip on the Icon Library view.
- Adds a Deprecation Notice on the individual Icon views.
- Adds a Deprecation Notice in the global site search.

## Related Icons Support
- Adds a "Related Icons" section on the full Icon view pages.
