### PR TITLE
Adjust Icon Library views

### DIFF
--- a/components/CarbonAd/CarbonAd.tsx
+++ b/components/CarbonAd/CarbonAd.tsx
@@ -14,7 +14,7 @@ const CarbonAd: FunctionComponent<CarbonAdProps> = ({ displayOnMobile = false })
   const carbonAdsRef = useRef<HTMLDivElement | null>(null);
   const { publicRuntimeConfig: { carbonAds } } = getConfig();
   const windowSize = useWindowSize();
-  const isMobileWidth = windowSize.width <= parseInt(classes['mobile-width']);
+  const isMobileWidth = windowSize.width > 0 && windowSize.width <= parseInt(classes['mobile-width']);
 
   useEffect(() => {
     if (carbonAdsRef.current && !carbonAdsRef.current.childNodes.length) {

--- a/components/Contributors/Contributors.module.scss
+++ b/components/Contributors/Contributors.module.scss
@@ -1,17 +1,5 @@
 .contributors {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(3, 1fr);
-}
-
-@media only screen and (max-width: ($tablet-width + 200)) {
-  .contributors {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media only screen and (max-width: $mobile-width) {
-  .contributors {
-    grid-template-columns: 1fr;
-  }
+  grid-template-columns: repeat(auto-fill, minmax(275px, 1fr));
 }

--- a/components/Footer/Footer.module.scss
+++ b/components/Footer/Footer.module.scss
@@ -126,3 +126,23 @@
     }
   }
 }
+
+@media only screen and (max-width: $mobile-width) {
+  .root {
+    margin-top: 0;
+  }
+
+  .summary {
+    a {
+      margin: 0 auto;
+    }
+
+    div {
+      display: none;
+    }
+  }
+
+  .columns {
+    display: none;
+  }
+}

--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -157,8 +157,12 @@
     width: calc(100% + 44px);
     z-index: 999;
 
-    & :not(:last-child) {
-      border-bottom: 1px solid hsl(var(--light-grey));
+    a {
+      padding: 1rem 0;
+
+      &:not(:last-child) {
+        border-bottom: 1px solid hsl(var(--light-grey));
+      }
     }
 
     > * {

--- a/components/IconGrid/IconGrid.module.scss
+++ b/components/IconGrid/IconGrid.module.scss
@@ -1,88 +1,30 @@
 .library {
   display: grid;
-  grid-gap: 20px;
-  grid-template-columns: repeat(6, 1fr);
+  grid-gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
 
   p {
-    font-size: .9rem;
+    font-size: .8rem;
     font-weight: 500;
   }
 
-  &.compact {
-    grid-gap: 10px;
-    grid-template-columns: repeat(9, 1fr);
+  &.comfortable {
+    grid-template-columns: repeat(auto-fill, minmax(105px, 1fr));
 
     p {
-      font-size: .8rem;
+      font-size: .75rem;
     }
   }
 
-  &.list {
-    grid-gap: 5px;
-    grid-template-columns: repeat(5, 1fr);
+  &.compact {
+    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
 
     .libraryIcon {
-      flex-direction: row;
-      height: 50px;
-      justify-content: flex-start;
-
-      svg {
-        flex: 1;
-      }
+      height: 60px;
 
       p {
-        flex: 3;
-        margin: 0 0 0 .5rem;
-        text-align: left;
+        display: none;
       }
-    }
-  }
-
-  @media only screen and (max-width: ($tablet-width + 500)) {
-    grid-template-columns: repeat(5, 1fr);
-
-    &.compact {
-      grid-template-columns: repeat(8, 1fr);
-    }
-
-    &.list {
-      grid-template-columns: repeat(4, 1fr);
-    }
-  }
-
-  @media only screen and (max-width: ($tablet-width + 400)) {
-    grid-template-columns: repeat(4, 1fr);
-
-    &.compact {
-      grid-template-columns: repeat(6, 1fr);
-    }
-
-    &.list {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-
-  @media only screen and (max-width: $tablet-width) {
-    grid-template-columns: repeat(3, 1fr);
-
-    &.compact {
-      grid-template-columns: repeat(4, 1fr);
-    }
-
-    &.list {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  @media only screen and (max-width: $mobile-width) {
-    grid-template-columns: repeat(2, 1fr);
-
-    &.compact {
-      grid-template-columns: repeat(3, 1fr);
-    }
-
-    &.list {
-      grid-template-columns: repeat(1, 1fr);
     }
   }
 }
@@ -95,7 +37,6 @@
   flex-direction: column;
   font-size: 80%;
   height: 130px;
-  justify-content: center;
   text-align: center;
   text-decoration: none;
   transition: background-color .2s ease-in-out;

--- a/components/IconGrid/IconGrid.tsx
+++ b/components/IconGrid/IconGrid.tsx
@@ -31,7 +31,7 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, modalHook,
   const categories = useCategories(library.id);
   const router = useRouter();
   const windowSize = useWindowSize();
-  const isMobileWidth = windowSize.width <= parseInt(classes['mobile-width']);
+  const isMobileWidth = windowSize.width > 0 && windowSize.width <= parseInt(classes['mobile-width']);
 
   useEffect(() => {
     const handleRouteChange = (url: string) => {
@@ -75,7 +75,7 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, modalHook,
           <ConditionalWrapper
             condition={!!icon.d}
             wrapper={(children: any) => (
-              <Tooltip arrow placement='top' title={<Fragment><strong>Icon Deprecated</strong><br/>Click for more info.</Fragment>}>
+              <Tooltip arrow placement='top' title={<Fragment><strong>Icon Deprecated</strong><br/>Click for more info</Fragment>}>
                 {children}
               </Tooltip>
             )}
@@ -87,13 +87,14 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, modalHook,
               disableRouter
               href={`/library/${library.id}/icon/${icon.n}`}
               onClick={(e: MouseEvent<HTMLAnchorElement>) => handleIconModalOpen(e, icon)}
+              title={!icon.d ? icon.n : undefined}
             >
               <CustomGridIcon gridSize={library.gridSize} path={icon.p} size={viewModes[viewMode as keyof typeof viewModes].iconSize} title={icon.n} />
               <p>{icon.n}</p>
             </Link>
           </ConditionalWrapper>
         )}
-        overscan={300}
+        overscan={viewMode === 'compact' ? 600 : 300}
         totalCount={icons.length}
         useWindowScroll
       />

--- a/components/IconLibrary/IconLibraryView.tsx
+++ b/components/IconLibrary/IconLibraryView.tsx
@@ -97,17 +97,23 @@ const IconLibraryView: FunctionComponent<IconLibraryViewProps> = ({
 
   // Responsive concerns
   const windowSize = useWindowSize();
-  const isMobileWidth = windowSize.width <= parseInt(classes['mobile-width']);
+  const isMobileWidth = windowSize.width > 0 && windowSize.width <= parseInt(classes['mobile-width']);
 
   // Library viewing
   const [ carbonKey, setCarbonKey ] = useState(new Date().toString());
-  const [ viewMode, setViewMode ] = useState(isMobileWidth ? 'compact' : 'comfortable');
+  const [ viewMode, setViewMode ] = useState('default');
   const { contributors } = useData();
   const categories = useCategories(libraryInfo.id);
   const filter = useMemo(() => ({
     author, category, deprecated: showDeprecated, term: debouncedSearchTerm, version
   }), [ author, category, debouncedSearchTerm, showDeprecated, version ]);
   const visibleIcons = useIcons(libraryInfo.id, filter);
+
+  useEffect(() => {
+    if (isMobileWidth) {
+      setViewMode('comfortable');
+    }
+  }, [ isMobileWidth ]);
 
   useEffect(() => {
     if (router.query.q) {

--- a/components/IconLibrary/LibraryViewMode.tsx
+++ b/components/IconLibrary/LibraryViewMode.tsx
@@ -8,10 +8,9 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Icon from '@mdi/react';
 import {
-  mdiApps,
   mdiChevronDown,
-  mdiFormatListBulleted,
-  mdiViewGrid
+  mdiViewComfy,
+  mdiViewModule
 } from '@mdi/js';
 
 interface LibraryViewModeMenuProps {
@@ -21,21 +20,23 @@ interface LibraryViewModeMenuProps {
   setViewMode: Function;
 };
 
+const mdiViewGridCompact = 'M2,5h2v2H2V5 M5,5h2v2H5V5 M8,5h2v2H8V5 M11,5h2v2h-2V5 M14,5h2v2h-2V5 M17,5h2v2h-2V5 M20,5h2v2h-2V5 M2,8h2v2H2V8 M5,8h2v2H5V8 M8,8h2v2H8V8 M11,8h2v2h-2V8 M14,8h2v2h-2V8 M17,8h2v2h-2V8 M20,8h2v2h-2V8 M2,11h2v2H2V11 M5,11h2v2H5V11 M8,11h2v2H8V11M11,11h2v2h-2V11 M14,11h2v2h-2V11 M17,11h2v2h-2V11 M20,11h2v2h-2V11 M2,14h2v2H2V14 M5,14h2v2H5V14 M8,14h2v2H8V14 M11,14h2v2h-2V14 M14,14h2v2h-2V14 M17,14h2v2h-2V14 M20,14h2v2h-2V14 M2,17h2v2H2V17 M5,17h2v2H5V17 M8,17h2v2H8V17 M11,17h2v2h-2V17 M14,17h2v2h-2V17 M17,17h2v2h-2V17 M20,17h2v2h-2V17';
 export const viewModes = {
-  comfortable: {
-    icon: mdiViewGrid,
+  default: {
+    icon: mdiViewModule,
     iconSize: 2,
+    name: 'Default'
+  },
+  // eslint-disable-next-line sort-keys
+  comfortable: {
+    icon: mdiViewComfy,
+    iconSize: 1.2,
     name: 'Comfortable'
   },
   compact: {
-    icon: mdiApps,
-    iconSize: 1.2,
+    icon: mdiViewGridCompact,
+    iconSize: 1,
     name: 'Compact'
-  },
-  list: {
-    icon: mdiFormatListBulleted,
-    iconSize: .8,
-    name: 'List'
   }
 };
 
@@ -82,7 +83,10 @@ const LibraryViewMode: FunctionComponent<LibraryViewModeMenuProps> = ({ color = 
           onClick={handleMenuClick}
           variant='contained'
         >
-          <Icon path={viewModes[currentView as keyof typeof viewModes].icon} size={1} />
+          <Icon
+            path={viewModes[currentView as keyof typeof viewModes].icon}
+            size={1}
+          />
         </Button>
         <Menu
           anchorEl={menuAnchor}
@@ -108,7 +112,10 @@ const LibraryViewMode: FunctionComponent<LibraryViewModeMenuProps> = ({ color = 
             onClick={() => setViewMode(mode)}
             variant={currentView === mode ? 'contained' : 'outlined'}
           >
-            <Icon path={viewModes[mode as keyof typeof viewModes].icon} size={1} />
+            <Icon
+              path={viewModes[mode as keyof typeof viewModes].icon}
+              size={1}
+            />
           </Button>
         </Tooltip>
       ))}

--- a/components/IconPreviewGenerator/IconPreviewGenerator.tsx
+++ b/components/IconPreviewGenerator/IconPreviewGenerator.tsx
@@ -29,7 +29,7 @@ const IconPreviewGenerator: FunctionComponent = () => {
   const canvas = usePreviewCanvas(iconName, iconPath, workInProgress, iconShadow);
 
   const windowSize = useWindowSize();
-  const isMobileWidth = windowSize.width <= parseInt(classes['mobile-width']);
+  const isMobileWidth = windowSize.width > 0 && windowSize.width <= parseInt(classes['mobile-width']);
 
   const triggerSvgUpload = (type: string) => {
     if (!svgUploader.current) {

--- a/components/IconView/IconView.tsx
+++ b/components/IconView/IconView.tsx
@@ -273,7 +273,7 @@ const IconView: FunctionComponent<IconViewProps> = ({ icon, libraryInfo, onClose
               {!!icon.relatedIcons?.length && (
                 <div className={classes.related}>
                   <h2>Related Icons</h2>
-                  <IconGrid icons={icon.relatedIcons} library={libraryInfo} updateUrl={false} viewMode='comfortable' />
+                  <IconGrid icons={icon.relatedIcons} library={libraryInfo} updateUrl={false} viewMode='default' />
                 </div>
               )}
             </Fragment>

--- a/components/LandingPageHeading/LandingPageHeading.tsx
+++ b/components/LandingPageHeading/LandingPageHeading.tsx
@@ -32,7 +32,7 @@ const LandingPageHeading: FunctionComponent<LandingPageHeadingProps> = ({
   title
 }) => {
   const windowSize = useWindowSize();
-  const isMobileWidth = windowSize.width <= parseInt(classes['mobile-width']);
+  const isMobileWidth = windowSize.width > 0 && windowSize.width <= parseInt(classes['mobile-width']);
 
   return (
     <div

--- a/components/LibraryCard/LibraryCard.module.scss
+++ b/components/LibraryCard/LibraryCard.module.scss
@@ -1,5 +1,4 @@
 .root {
-  border-radius: 1.25rem;
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/components/LibraryCard/LibraryCard.tsx
+++ b/components/LibraryCard/LibraryCard.tsx
@@ -18,7 +18,7 @@ export interface LibraryCardProps {
 
 const LibraryButton = styled(Button)(({ theme }) => ({
   '&:hover': {
-    backgroundColor: 'white',
+    backgroundColor: 'hsl(var(--medium-grey))',
     color: theme.palette.primary.main
   },
   backgroundColor: 'white',

--- a/components/MDIWelcome/MDIWelcome.tsx
+++ b/components/MDIWelcome/MDIWelcome.tsx
@@ -19,7 +19,7 @@ interface MDIWelcomeProps {
 
 const MDIWelcome: FunctionComponent<MDIWelcomeProps> = ({ handleClose }) => {
   const windowSize = useWindowSize();
-  const isMobileWidth = windowSize.width <= parseInt(classes['mobile-width']);
+  const isMobileWidth = windowSize.width > 0 && windowSize.width <= parseInt(classes['mobile-width']);
 
   return (
     <Dialog

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "contributors": [
     "Michael Irigoyen <michael.irigoyen@pictogrammers.com>",
     "Austin Andrews <austin.andrews@pictogrammers.com>",
-    "Quentin Stoeckel <stoeckel.quentin@gmail.com>"
+    "Quentin Stoeckel <stoeckel.quentin@gmail.com>",
+    "Andrej Sharapov <an.sharapov90@gmail.com>"
   ],
   "engines": {
     "node": "18.x"

--- a/pages/contributor/[...slug].tsx
+++ b/pages/contributor/[...slug].tsx
@@ -1,4 +1,4 @@
-import { Fragment, SyntheticEvent, useMemo, useState } from 'react';
+import { Fragment, SyntheticEvent, useEffect, useMemo, useState } from 'react';
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import getConfig from 'next/config';
 import cx from 'clsx';
@@ -70,10 +70,10 @@ const ContributorPage: NextPage<ContributorPageProps> = ({ contributor }) => {
 
   const { publicRuntimeConfig: { libraries: { icons: iconLibraries } } } = getConfig();
   const windowSize = useWindowSize();
-  const isMobileWidth = windowSize.width <= parseInt(classes['mobile-width']);
+  const isMobileWidth = windowSize.width > 0 && windowSize.width <= parseInt(classes['mobile-width']);
 
   const [ currentTab, setCurrentTab ] = useState(0);
-  const [ viewMode, setViewMode ] = useState(isMobileWidth ? 'compact' : 'comfortable');
+  const [ viewMode, setViewMode ] = useState('default');
 
   const currentLibraryId = authorLibraries[currentTab];
   const currentLibrary = iconLibraries.find((library: IconLibrary) => library.id === currentLibraryId);
@@ -82,6 +82,12 @@ const ContributorPage: NextPage<ContributorPageProps> = ({ contributor }) => {
   const contributorColor = core ? '--primary-color' : '--dark-cyan';
 
   const handleChange = (event: SyntheticEvent, newValue: number) => setCurrentTab(newValue);
+
+  useEffect(() => {
+    if (isMobileWidth) {
+      setViewMode('comfortable');
+    }
+  }, [ isMobileWidth ]);
 
   return (
     <div className={classes.root}>

--- a/public/data/.gitignore
+++ b/public/data/.gitignore
@@ -1,3 +1,3 @@
-# This directory contains the prebuilt JSON files and supporting images for all contributors.
+# This directory contains the prebuilt JSON files containing all data to run the site
 *
 !.gitignore

--- a/styles/pages/contributor.module.scss
+++ b/styles/pages/contributor.module.scss
@@ -107,7 +107,7 @@
 .repos {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   padding: 1rem;
 }
 
@@ -137,9 +137,5 @@
     & > span {
       display: none;
     }
-  }
-
-  .repos {
-    grid-template-columns: 1fr;
   }
 }

--- a/styles/pages/index.module.scss
+++ b/styles/pages/index.module.scss
@@ -21,7 +21,7 @@
     align-items: center;
     display: grid;
     grid-gap: 3rem 5rem;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     justify-items: center;
     max-width: 1080px;
     width: 100%;
@@ -62,14 +62,10 @@
   align-items: center;
   display: grid;
   grid-gap: 3rem;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   justify-content: space-between;
   margin: 3rem auto;
   max-width: 1080px;
-
-  @media only screen and (max-width: $mobile-width) {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  }
 }
 
 .join {

--- a/styles/pages/landing.module.scss
+++ b/styles/pages/landing.module.scss
@@ -55,16 +55,8 @@
 .cards {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   padding: 1rem;
-
-  @media only screen and (max-width: ($tablet-width + 200)) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  @media only screen and (max-width: $mobile-width) {
-    grid-template-columns: 1fr;
-  }
 }
 
 .fullCards {

--- a/styles/theme.module.scss
+++ b/styles/theme.module.scss
@@ -49,6 +49,7 @@
 
 :export {
   /* stylelint-disable color-no-hex */
+  // These are exported to be consumed by MUI
   neutral-color: #3b5f68;
   primary-color: #530066;
   secondary-color: #258dad;


### PR DESCRIPTION
- Removes the "List" library view.
- Renames the following views:
  - "Comfortable" => "Default"
  - "Compact" => "Comfortable"
  - "List" => "Compact"
- Introduces a new Compact mode that does not display the icon's names. This is similar to how the old site displayed them. To see an icon name, place your mouse cursor over the icon for a few seconds, or click/tap an icon to see its details.

Closes #46.