### PR TITLE
Icon Grid in Firefox, Site Search Fixes

### DIFF
--- a/components/IconGrid/IconGrid.module.scss
+++ b/components/IconGrid/IconGrid.module.scss
@@ -1,7 +1,8 @@
 .library {
   display: grid;
   grid-gap: 10px;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fill, 150px);
+  justify-content: space-around;
 
   p {
     font-size: .8rem;
@@ -9,7 +10,7 @@
   }
 
   &.comfortable {
-    grid-template-columns: repeat(auto-fill, minmax(105px, 1fr));
+    grid-template-columns: repeat(auto-fill, 105px);
 
     p {
       font-size: .75rem;
@@ -17,7 +18,7 @@
   }
 
   &.compact {
-    grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+    grid-template-columns: repeat(auto-fill, 60px);
 
     .libraryIcon {
       height: 60px;

--- a/components/IconGrid/IconGrid.tsx
+++ b/components/IconGrid/IconGrid.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { VirtuosoGrid } from 'react-virtuoso';
 import Dialog from '@mui/material/Dialog';
 import Tooltip from '@mui/material/Tooltip';
+import Skeleton from '@mui/material/Skeleton';
 
 import useCategories, { CategoryProps } from '../../hooks/useCategories';
 import useWindowSize from '../../hooks/useWindowSize';
@@ -69,6 +70,14 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, modalHook,
   return (
     <Fragment>
       <VirtuosoGrid
+        components={{
+          ScrollSeekPlaceholder: () => (
+            <div className={cx(classes.libraryIcon, classes.iconLoading)}>
+              <Skeleton height={viewModes[viewMode as keyof typeof viewModes].iconSize * 40} width={viewModes[viewMode as keyof typeof viewModes].iconSize * 24} />
+              {viewMode !== 'compact' && <Skeleton height={24} width={100} />}
+            </div>
+          )
+        }}
         data={icons}
         listClassName={cx(classes.library, classes[viewMode])}
         itemContent={(index, icon: IconLibraryIcon) => (
@@ -94,7 +103,11 @@ const IconGrid: FunctionComponent<IconGridProps> = ({ icons, library, modalHook,
             </Link>
           </ConditionalWrapper>
         )}
-        overscan={viewMode === 'compact' ? 600 : 300}
+        overscan={1000}
+        scrollSeekConfiguration={{
+          enter: (velocity) => Math.abs(velocity) > 1000,
+          exit: (velocity) => Math.abs(velocity) < 30
+        }}
         totalCount={icons.length}
         useWindowScroll
       />

--- a/components/SiteSearch/SiteSearch.tsx
+++ b/components/SiteSearch/SiteSearch.tsx
@@ -131,7 +131,7 @@ const SiteSearch: FunctionComponent = () => {
         filterOptions={(options) => options}
         freeSolo
         fullWidth
-        getOptionLabel={(option: any) => option.id}
+        getOptionLabel={(option: any) => option.id || searchTerm}
         onInputChange={(e: SyntheticEvent, value: string) => setSearchTerm(value)}
         onClose={closeSearchResults}
         onOpen={openSearchResults}
@@ -144,6 +144,11 @@ const SiteSearch: FunctionComponent = () => {
             classes={{ root: classes.searchBox }}
             InputProps={{
               ...params.InputProps,
+              onKeyDown: (e) => {
+                if (e.key === 'Enter') {
+                  e.stopPropagation();
+                }
+              },
               startAdornment: (
                 <InputAdornment position='start' sx={{ marginLeft: '5px', marginRight: 0 }}>
                   <Icon path={mdiMagnify} size={1} />
@@ -241,10 +246,12 @@ const SiteSearch: FunctionComponent = () => {
                   );
                 })}
                 {isLibrary && showMoreLink && (
-                  <ListItemButton component={Link} href={`/library/${option.id}/?q=${encodeURIComponent(debouncedSearchTerm)}`} onClick={closeSearchResults}>
-                    <Icon path={mdiDotsHorizontalCircleOutline} size={1} />
-                    <ListItemText>See All Results</ListItemText>
-                  </ListItemButton>
+                  <ListItem key={`more-${option.id}`} sx={{ padding: 0 }}>
+                    <ListItemButton component={Link} href={`/library/${option.id}/?q=${encodeURIComponent(debouncedSearchTerm)}`} onClick={closeSearchResults}>
+                      <Icon path={mdiDotsHorizontalCircleOutline} size={1} />
+                      <ListItemText>See All Results</ListItemText>
+                    </ListItemButton>
+                  </ListItem>
                 )}
               </List>
             </div>


### PR DESCRIPTION
Fixes #51, #52.

## Icon Grid Changes
- Adjusts some styling on the `IconGrid` to work around shortcomings Firefox has dealing with `fr` units.
- Adjusting the `overscan` of the `IconGrid` slightly to handle quicker scrollers.
- Added Skeletons when someone scrolls way too fast on the `IconGrid`.

## Site Search Changes
- Handle when someone presses `Enter` in the site-search by ignoring the keypress. This allows time for the results to appear instead of dropping focus.
- Fixes an issue where, in some cases, the search box would display the word "undefined".