### PR TITLE
Add dev scripts for generating certs on Windows

### DIFF
--- a/.dev/create-certs.bat
+++ b/.dev/create-certs.bat
@@ -1,0 +1,12 @@
+@echo off
+
+set "CERT_STORE=.dev/certs"
+set "KEY_FILE=./%CERT_STORE%/dev.pictogrammers-key.pem"
+set "CERT_FILE=./%CERT_STORE%/dev.pictogrammers.pem"
+
+IF NOT EXIST %KEY_FILE% IF NOT EXIST %CERT_FILE% (
+  choco install mkcert
+  mkcert -install
+  mkdir "%CERT_STORE%"
+  mkcert -key-file "%KEY_FILE%" -cert-file "%CERT_FILE%" dev.pictogrammers.com dev-api.pictogrammers.com localhost 127.0.0.1 ::1
+)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 
 1. Clone this repository.
 2. Generate your development certificates.
-   - On Mac, run `npm run dev:certs`. You need [Homebrew](https://brew.sh/) to be installed.
+   - On Mac, run `npm run certs:mac`. You need [Homebrew](https://brew.sh/) to be installed.
+   - On Windows, run `npm run certs:win`. You need [Chocolatey](https://chocolatey.org/) to be installed.
    - On any other platform, see [Generating Dev Certs](#generating-dev-certs).
    - Once your certs are generated, you do not need to run this command again unless you delete the certs or they expire.
 3. Run `npm i`.
@@ -36,7 +37,7 @@ See <https://pictogrammers.com/docs/contribute/website/> for more details about 
 
 ### Generating Dev Certs
 
-If you are not using a Mac, you will need to [follow the instructions on the `mkcert` GitHub page](https://github.com/FiloSottile/mkcert) to install the version for your platform.
+If you are not using Mac or Windows, you will need to [follow the instructions on the `mkcert` GitHub page](https://github.com/FiloSottile/mkcert) to install the version for your platform.
 
 You need to generate certs for the following two domains:
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces",
+    "certs:mac": "./.dev/create-certs.sh",
+    "certs:win": "./.dev/create-certs.bat",
     "dev": "concurrently -c \"auto\" \"npm:dev:framework\" \"npm:dev:api\" \"npm:dev:client\"",
     "dev:api": "npm run dev --workspace=api",
-    "dev:certs": "./.dev/create-certs.sh",
     "dev:client": "npm run dev --workspace=client",
     "dev:framework": "docker-compose -f ./.dev/docker-compose.yml up",
     "dev:framework:down": "docker-compose -f ./.dev/docker-compose.yml down",


### PR DESCRIPTION
## Proposed Changes

- Adds a new `npm run certs:win` command for auto-generating dev certs on Windows.
- Renames `npm run dev:certs` to `npm run certs:mac`.

## Types of Changes

What types of changes does your code introduce?
<!-- Put an `x` in the boxes that apply. -->

- [x] Documentation Update
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing](https://pictogrammers.com/docs/contribute/website/) doc.
- [x] Lint passes locally with my changes.
- [x] I have added necessary documentation (if appropriate).

## Additional Information

<!-- Please provide us with any other details you think would be beneficial for us to know while considering your changes. If your changes are complex in nature, let us know why you implemented your solution the way you did, what alternatives you considered, etc. -->
