### PR TITLE
Fix Icon import in React

### DIFF
--- a/client/components/IconUsageExamples/ExampleReact.tsx
+++ b/client/components/IconUsageExamples/ExampleReact.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import cx from 'clsx';
 import Button from '@mui/material/Button';
-import Icon from '@mdi/react';
+import { Icon } from '@mdi/react';
 import { mdiArrowRight } from '@mdi/js';
 
 import Link from '@/components/Link/Link';

--- a/docs/library/mdi/getting-started/react.mdx
+++ b/docs/library/mdi/getting-started/react.mdx
@@ -18,7 +18,7 @@ npm install @mdi/react @mdi/js
 
 ```jsx
 import React, { Component } from 'react';
-import Icon from '@mdi/react';
+import { Icon } from '@mdi/react';
 import { mdiAccount } from '@mdi/js';
 
 class App extends Component {


### PR DESCRIPTION
## Proposed Changes

This PR fix a bug happing in production build where the `<Icon />` is React was not imported correctly resulting in this error: 
```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.
```
Source: https://reactjs.org/docs/error-decoder.html/?invariant=130&args[]=object&args[]=

## Types of Changes

What types of changes does your code introduce?
<!-- Put an `x` in the boxes that apply. -->

- [x] Documentation Update
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing](https://pictogrammers.com/docs/contribute/website/) doc.
- [ ] Lint passes locally with my changes.
- [x] I have added necessary documentation (if appropriate).

## Additional Information

Linked issue and PR: 
- React doc: https://github.com/Templarian/MaterialDesign-React/pull/83
- Issue: https://github.com/Templarian/MaterialDesign-React/issues/69
