### PR TITLE
fix: incorrect content type declaration in htaccess

### DIFF
--- a/client/public/.htaccess
+++ b/client/public/.htaccess
@@ -38,7 +38,7 @@ RewriteRule ^(.*)$ $1.br [QSA,L]
 </Files>
 
 <Files *.json.br>
-  AddType "application.json" .br
+  AddType "application/json" .br
   AddEncoding br .br
   SetEnv no-gzip 1
 </Files>


### PR DESCRIPTION
## Proposed Changes

I found that there is an error on the current page. When investigating i saw that there is a content type mismatch instead of application/json the return type was application.json

## Types of Changes

What types of changes does your code introduce?

- [ ] Documentation Update
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [Contributing](https://pictogrammers.com/docs/contribute/website/) doc.
- [X] Lint passes locally with my changes.
- [ ] I have added necessary documentation (if appropriate).

## Additional Information

I am not aware of your hosting setup. I tried to estimate from the data I could scrape, and it worked for me. It may be possible that depending on the architecture the change will not fully fix the issue. 
